### PR TITLE
Update homepage description to Traditional Chinese

### DIFF
--- a/resource/public/index.html
+++ b/resource/public/index.html
@@ -8,7 +8,7 @@
 <h1>MoneyPrinterTurbo</h1>
 <a href="https://github.com/harry0703/MoneyPrinterTurbo">https://github.com/harry0703/MoneyPrinterTurbo</a>
 <p>
-    只需提供一个视频 主题 或 关键词 ，就可以全自动生成视频文案、视频素材、视频字幕、视频背景音乐，然后合成一个高清的短视频。
+    只需提供一個視頻 主題 或 關鍵詞 ，就可以全自動生成視頻文案、視頻素材、視頻字幕、視頻背景音樂，然後合成一個高清的短視頻。
 </p>
 
 <p>


### PR DESCRIPTION
## Summary
- convert Chinese description text on the homepage from Simplified to Traditional characters
- add newline at EOF

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68663b5a2da4832585e3184f6ea8f1fe