### PR TITLE
Fix quota exhaustion message

### DIFF
--- a/app/services/llm.py
+++ b/app/services/llm.py
@@ -347,8 +347,8 @@ Generate a script for a video, depending on the subject of the video.
             else:
                 logging.error("gpt returned an empty response")
 
-            # g4f may return an error message
-            if final_script and "当日额度已消耗完" in final_script:
+            # g4f may return an error message like "當日額度已消耗完"
+            if final_script and "當日額度已消耗完" in final_script:
                 raise ValueError(final_script)
 
             if final_script:


### PR DESCRIPTION
## Summary
- update the quota exhaustion string to `當日額度已消耗完`
- clarify example error message in comment

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68663b5aea9c832598e7d90cd30b2f3e