### PR TITLE
Replace Simplified Chinese samples with Traditional

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@
 <table>
 <thead>
 <tr>
-<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《如何增加生活的乐趣》</th>
-<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《金钱的作用》<br>更真实的合成声音</th>
-<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《生命的意义是什么》</th>
+<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《如何增加生活的樂趣》</th>
+<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《金錢的作用》<br>更真實的合成聲音</th>
+<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji> 《生命的意義是什麼》</th>
 </tr>
 </thead>
 <tbody>
@@ -98,8 +98,8 @@
 <table>
 <thead>
 <tr>
-<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji>《生命的意义是什么》</th>
-<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji>《为什么要运动》</th>
+<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji>《生命的意義是什麼》</th>
+<th align="center"><g-emoji class="g-emoji" alias="arrow_forward">▶️</g-emoji>《為什麼要運動》</th>
 </tr>
 </thead>
 <tbody>

--- a/test/services/test_task.py
+++ b/test/services/test_task.py
@@ -29,8 +29,8 @@ class TestTaskService(unittest.TestCase):
             ))
 
         params = VideoParams(
-            video_subject="金钱的作用",
-            video_script="金钱不仅是交换媒介，更是社会资源的分配工具。它能满足基本生存需求，如食物和住房，也能提供教育、医疗等提升生活品质的机会。拥有足够的金钱意味着更多选择权，比如职业自由或创业可能。但金钱的作用也有边界，它无法直接购买幸福、健康或真诚的人际关系。过度追逐财富可能导致价值观扭曲，忽视精神层面的需求。理想的状态是理性看待金钱，将其作为实现目标的工具而非终极目的。",
+            video_subject="金錢的作用",
+            video_script="金錢不僅是交換媒介，更是社會資源的分配工具。它能滿足基本生存需求，如食物和住房，也能提供教育、醫療等提升生活品質的機會。擁有足夠的金錢意味著更多選擇權，比如職業自由或創業可能。但金錢的作用也有邊界，它無法直接購買幸福、健康或真誠的人際關係。過度追逐財富可能導致價值觀扭曲，忽視精神層面的需求。理想的狀態是理性看待金錢，將其作為實現目標的工具而非終極目的。",
             video_terms="money importance, wealth and society, financial freedom, money and happiness, role of money",
             video_aspect="9:16",
             video_concat_mode="random",

--- a/test/services/test_video.py
+++ b/test/services/test_video.py
@@ -68,7 +68,7 @@ class TestVideoService(unittest.TestCase):
             self.assertIn("\n", wrapped_text_en)
             
             # test chinese text wrapping
-            test_text_zh = "这是一段用来测试中文长句换行的文本内容，应该会根据宽度限制进行换行处理"
+            test_text_zh = "這是一段用來測試中文長句換行的文本內容，應該會根據寬度限制進行換行處理"
             wrapped_text_zh, text_height_zh = vd.wrap_text(
                 text=test_text_zh,
                 max_width=300,

--- a/test/services/test_voice.py
+++ b/test/services/test_voice.py
@@ -22,9 +22,9 @@ It's an existential inquiry that encourages us to reflect on our values, desires
 """
 
 text_zh = """
-预计未来3天深圳冷空气活动频繁，未来两天持续阴天有小雨，出门带好雨具；
-10-11日持续阴天有小雨，日温差小，气温在13-17℃之间，体感阴凉；
-12日天气短暂好转，早晚清凉；
+預計未來3天深圳冷空氣活動頻繁，未來兩天持續陰天有小雨，出門帶好雨具；
+10-11日持續陰天有小雨，日溫差小，氣溫在13-17℃之間，體感陰涼；
+12日天氣短暫好轉，早晚清涼；
 """
 
 voice_rate=1.0
@@ -46,10 +46,10 @@ class TestVoiceService(unittest.TestCase):
             parts = voice_name.split(":")
             if len(parts) >= 3:
                 model = parts[1]
-                # 移除性别后缀，例如 "alex-Male" -> "alex"
+                # 移除性別後綴，例如 "alex-Male" -> "alex"
                 voice_with_gender = parts[2]
                 voice = voice_with_gender.split("-")[0]
-                # 构建完整的voice参数，格式为 "model:voice"
+                # 構建完整的voice參數，格式為 "model:voice"
                 full_voice = f"{model}:{voice}"
                 voice_file = f"{temp_dir}/tts-siliconflow-{voice}.mp3"
                 subtitle_file = f"{temp_dir}/tts-siliconflow-{voice}.srt"


### PR DESCRIPTION
## Summary
- update demo titles in README from Simplified to Traditional Chinese
- update test samples in `test/services` to Traditional Chinese

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_68663b5c44948325a7d1cc20d6cc6ab6